### PR TITLE
Add a fat interface for *os.File; TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go:
+- tip
+- 1.8.5
+- 1.9.2
+sudo: false
+notifications:
+  email:
+    on_success: never
+    on_failure: always
+install: true

--- a/os.go
+++ b/os.go
@@ -1,0 +1,28 @@
+package fatinterfaces
+
+import (
+	"io"
+	"os"
+)
+
+// OsFile is the interface describing an *os.File.
+type OsFile interface {
+	io.Closer
+	io.Seeker
+	io.Reader
+	io.ReaderAt
+	io.Writer
+	io.WriterAt
+
+	Chdir() error
+	Chmod(mode os.FileMode) error
+	Chown(uid, gid int) error
+	Fd() uintptr
+	Name() string
+	Readdir(n int) ([]os.FileInfo, error)
+	Readdirnames(n int) (names []string, err error)
+	Stat() (os.FileInfo, error)
+	Sync() error
+	Truncate(size int64) error
+	WriteString(s string) (n int, err error)
+}

--- a/os_test.go
+++ b/os_test.go
@@ -1,0 +1,10 @@
+package fatinterfaces
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOsFile(t *testing.T) {
+	var _ OsFile = (*os.File)(nil)
+}


### PR DESCRIPTION
This adds an interface definition to describe the `*os.File` type.

Signed-off-by: Tim Heckman <t@heckman.io>