### PR TITLE
Add interfaces to cover some net/http types

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,0 +1,66 @@
+package fatinterfaces
+
+import (
+	"context"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+)
+
+// NetHTTPClient is an interface to describe an *http.Client.
+type NetHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+	Get(url string) (*http.Response, error)
+	Head(url string) (*http.Response, error)
+	Post(url string, contentType string, body io.Reader) (*http.Response, error)
+	PostForm(url string, data url.Values) (*http.Response, error)
+}
+
+// NetHTTPHeader is an interface to describe an http.Header.
+type NetHTTPHeader interface {
+	Add(key, value string)
+	Del(key string)
+	Get(key string) string
+	Set(key, value string)
+	Write(w io.Writer) error
+	WriteSubset(w io.Writer, exclude map[string]bool) error
+}
+
+// NetHTTPRequest is an interface to describe an *http.Request.
+type NetHTTPRequest interface {
+	AddCookie(c *http.Cookie)
+	BasicAuth() (username, password string, ok bool)
+	Context() context.Context
+	Cookie(name string) (*http.Cookie, error)
+	Cookies() []*http.Cookie
+	FormFile(key string) (multipart.File, *multipart.FileHeader, error)
+	FormValue(key string) string
+	MultipartReader() (*multipart.Reader, error)
+	ParseForm() error
+	ParseMultipartForm(maxMemory int64) error
+	PostFormValue(key string) string
+	ProtoAtLeast(major, minor int) bool
+	Referer() string
+	SetBasicAuth(username, password string)
+	UserAgent() string
+	WithContext(ctx context.Context) *http.Request
+	Write(w io.Writer) error
+	WriteProxy(w io.Writer) error
+}
+
+// NetHTTPResponse is an interface to describe an *http.Response.
+type NetHTTPResponse interface {
+	Cookies() []*http.Cookie
+	Location() (*url.URL, error)
+	ProtoAtLeast(major, minor int) bool
+	Write(w io.Writer) error
+}
+
+// NetHTTPServeMux is an interface to describe an *http.ServeMux.
+type NetHTTPServeMux interface {
+	Handle(pattern string, handler http.Handler)
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+	Handler(r *http.Request) (h http.Handler, pattern string)
+	ServeHTTP(w http.ResponseWriter, r *http.Request)
+}

--- a/http_go18.go
+++ b/http_go18.go
@@ -1,0 +1,20 @@
+// +build !go19
+
+package fatinterfaces
+
+import (
+	"context"
+	"io"
+	"net"
+)
+
+// NetHTTPServer is an interface to describe an *http.Server.
+type NetHTTPServer interface {
+	io.Closer
+
+	ListenAndServe() error
+	ListenAndServeTLS(certFile, keyFile string) error
+	Serve(l net.Listener) error
+	SetKeepAlivesEnabled(v bool)
+	Shutdown(ctx context.Context) error
+}

--- a/http_go19.go
+++ b/http_go19.go
@@ -1,0 +1,22 @@
+// +build go19
+
+package fatinterfaces
+
+import (
+	"context"
+	"io"
+	"net"
+)
+
+// NetHTTPServer is an interface to describe an *http.Server.
+type NetHTTPServer interface {
+	io.Closer
+
+	ListenAndServe() error
+	ListenAndServeTLS(certFile, keyFile string) error
+	RegisterOnShutdown(f func())
+	Serve(l net.Listener) error
+	ServeTLS(l net.Listener, certFile, keyFile string) error
+	SetKeepAlivesEnabled(v bool)
+	Shutdown(ctx context.Context) error
+}

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,30 @@
+package fatinterfaces
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNetHTTPClient(t *testing.T) {
+	var _ NetHTTPClient = (*http.Client)(nil)
+}
+
+func TestNetHTTPHeader(t *testing.T) {
+	var _ NetHTTPHeader = (http.Header)(nil)
+}
+
+func TestNetHTTPRequest(t *testing.T) {
+	var _ NetHTTPRequest = (*http.Request)(nil)
+}
+
+func TestNetHTTPResponse(t *testing.T) {
+	var _ NetHTTPResponse = (*http.Response)(nil)
+}
+
+func TestNetHTTPServeMux(t *testing.T) {
+	var _ NetHTTPServeMux = (*http.ServeMux)(nil)
+}
+
+func TestNetHTTPServer(t *testing.T) {
+	var _ NetHTTPServer = (*http.Server)(nil)
+}


### PR DESCRIPTION
* `*http.Client`
* `http.Header`
* `*http.Request`
* `*http.Response`
* `*http.ServeMux`
* `*http.Server`

Signed-off-by: Tim Heckman <t@heckman.io>